### PR TITLE
Remove "runtime: nodejs" config

### DIFF
--- a/api/email.ts
+++ b/api/email.ts
@@ -2,10 +2,6 @@ import sgMail from "@sendgrid/mail";
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import type { EmailData } from "src/hooks";
 
-export const config = {
-  runtime: "nodejs",
-};
-
 type SendGridMessage = {
   to: string;
   from: string;


### PR DESCRIPTION
This value is not necessary (Node.js is the default), and the semantics of that value are planned on being changed in the future.